### PR TITLE
Added repartition flag, precommit hooks, updated tests and experiment launch script and experimental conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ algorithm_paper.pdf
 *.out
 algorithm_paper_v1.pdf
 __pycache__
+experiments/results
+.venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+    -   repo: https://github.com/pre-commit/pre-commit-hooks
+        rev: v3.2.0  # Use the ref you want to point at
+        hooks:
+        -   id: check-added-large-files
+    -   repo: https://github.com/psf/black
+        rev: 20.8b1
+        hooks:
+        -   id: black

--- a/experiments/conditions.json
+++ b/experiments/conditions.json
@@ -357,6 +357,7 @@
         "mem": 200,
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
+        "alg": "baseline",
         "a": "(3500, 3500, 3500)",
         "i": "(350, 350, 350)",
         "o": "(250, 250, 250)"
@@ -366,6 +367,7 @@
         "account": "vhs",
         "mem": 200,
         "cwd": "/disk0/vhs/repartition",
+        "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "baseline",
         "a": "(3500, 3500, 3500)",
         "i": "(250, 250, 250)",

--- a/experiments/conditions.json
+++ b/experiments/conditions.json
@@ -138,9 +138,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "keep",
-        "a": "(8000, 8000, 8000)",
-        "i": "(800, 800, 800)",
-        "o": "(4000, 4000, 4000)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(1000, 1000, 1000)",
+        "o": "(3000, 3000, 3000)"
     },
     {
         "name": "bi_1b_200G_keep",
@@ -149,9 +149,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "keep",
-        "a": "(8000, 8000, 8000)",
-        "i": "(4000, 4000, 4000)",
-        "o": "(800, 800, 800)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(3000, 3000, 3000)",
+        "o": "(1000, 1000, 1000)"
     },
     {
         "name": "bi_2a_200G_keep",
@@ -160,8 +160,8 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "keep",
-        "a": "(8000, 8000, 8000)",
-        "i": "(800, 800, 800)",
+        "a": "(6000, 6000, 6000)",
+        "i": "(1000, 1000, 1000)",
         "o": "(2000, 2000, 2000)"
     },
     {
@@ -171,9 +171,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "keep",
-        "a": "(8000, 8000, 8000)",
+        "a": "(6000, 6000, 6000)",
         "i": "(2000, 2000, 2000)",
-        "o": "(800, 800, 800)"
+        "o": "(1000, 1000, 1000)"
     },
     {
         "name": "bi_3a_200G_keep",
@@ -182,9 +182,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "keep",
-        "a": "(8000, 8000, 8000)",
-        "i": "(800, 800, 800)",
-        "o": "(1600, 1600, 1600)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(1000, 1000, 1000)",
+        "o": "(1500, 1500, 1500)"
     },
     {
         "name": "bi_3b_200G_keep",
@@ -193,9 +193,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "keep",
-        "a": "(8000, 8000, 8000)",
-        "i": "(1600, 1600, 1600)",
-        "o": "(800, 800, 800)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(1500, 1500, 1500)",
+        "o": "(1000, 1000, 1000)"
     },
     {
         "name": "bi_4a_200G_keep",
@@ -204,9 +204,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "keep",
-        "a": "(8000, 8000, 8000)",
-        "i": "(800, 800, 800)",
-        "o": "(1000, 1000, 1000)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(1000, 1000, 1000)",
+        "o": "(1200, 1200, 1200)"
     },
     {
         "name": "bi_4b_200G_keep",
@@ -215,9 +215,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "keep",
-        "a": "(8000, 8000, 8000)",
-        "i": "(1000, 1000, 1000)",
-        "o": "(800, 800, 800)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(1200, 1200, 1200)",
+        "o": "(1000, 1000, 1000)"
     },
     {
         "name": "bi_5a_200G_keep",
@@ -226,9 +226,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "keep",
-        "a": "(8000, 8000, 8000)",
-        "i": "(800, 800, 800)",
-        "o": "(500, 500, 500)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(1000, 1000, 1000)",
+        "o": "(750, 750, 750)"
     },
     {
         "name": "bi_5b_200G_keep",
@@ -237,9 +237,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "keep",
-        "a": "(8000, 8000, 8000)",
-        "i": "(500, 500, 500)",
-        "o": "(800, 800, 800)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(750, 750, 750)",
+        "o": "(1000, 1000, 1000)"
     },
     {
         "name": "bi_6a_200G_keep",
@@ -248,9 +248,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "keep",
-        "a": "(8000, 8000, 8000)",
-        "i": "(800, 800, 800)",
-        "o": "(400, 400, 400)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(1000, 1000, 1000)",
+        "o": "(600, 600, 600)"
     },
     {
         "name": "bi_6b_200G_keep",
@@ -259,9 +259,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "keep",
-        "a": "(8000, 8000, 8000)",
-        "i": "(400, 400, 400)",
-        "o": "(800, 800, 800)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(600, 600, 600)",
+        "o": "(1000, 1000, 1000)"
     },
     {
         "name": "si_1a_200G_baseline",
@@ -402,9 +402,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "baseline",
-        "a": "(8000, 8000, 8000)",
-        "i": "(800, 800, 800)",
-        "o": "(4000, 4000, 4000)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(1000, 1000, 1000)",
+        "o": "(3000, 3000, 3000)"
     },
     {
         "name": "bi_1b_200G_baseline",
@@ -413,9 +413,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "baseline",
-        "a": "(8000, 8000, 8000)",
-        "i": "(4000, 4000, 4000)",
-        "o": "(800, 800, 800)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(3000, 3000, 3000)",
+        "o": "(1000, 1000, 1000)"
     },
     {
         "name": "bi_2a_200G_baseline",
@@ -424,8 +424,8 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "baseline",
-        "a": "(8000, 8000, 8000)",
-        "i": "(800, 800, 800)",
+        "a": "(6000, 6000, 6000)",
+        "i": "(1000, 1000, 1000)",
         "o": "(2000, 2000, 2000)"
     },
     {
@@ -435,9 +435,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "baseline",
-        "a": "(8000, 8000, 8000)",
+        "a": "(6000, 6000, 6000)",
         "i": "(2000, 2000, 2000)",
-        "o": "(800, 800, 800)"
+        "o": "(1000, 1000, 1000)"
     },
     {
         "name": "bi_3a_200G_baseline",
@@ -446,9 +446,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "baseline",
-        "a": "(8000, 8000, 8000)",
-        "i": "(800, 800, 800)",
-        "o": "(1600, 1600, 1600)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(1000, 1000, 1000)",
+        "o": "(1500, 1500, 1500)"
     },
     {
         "name": "bi_3b_200G_baseline",
@@ -457,9 +457,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "baseline",
-        "a": "(8000, 8000, 8000)",
-        "i": "(1600, 1600, 1600)",
-        "o": "(800, 800, 800)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(1500, 1500, 1500)",
+        "o": "(1000, 1000, 1000)"
     },
     {
         "name": "bi_4a_200G_baseline",
@@ -468,9 +468,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "baseline",
-        "a": "(8000, 8000, 8000)",
-        "i": "(800, 800, 800)",
-        "o": "(1000, 1000, 1000)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(1000, 1000, 1000)",
+        "o": "(1200, 1200, 1200)"
     },
     {
         "name": "bi_4b_200G_baseline",
@@ -479,9 +479,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "baseline",
-        "a": "(8000, 8000, 8000)",
-        "i": "(1000, 1000, 1000)",
-        "o": "(800, 800, 800)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(1200, 1200, 1200)",
+        "o": "(1000, 1000, 1000)"
     },
     {
         "name": "bi_5a_200G_baseline",
@@ -490,9 +490,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "baseline",
-        "a": "(8000, 8000, 8000)",
-        "i": "(800, 800, 800)",
-        "o": "(500, 500, 500)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(1000, 1000, 1000)",
+        "o": "(750, 750, 750)"
     },
     {
         "name": "bi_5b_200G_baseline",
@@ -501,9 +501,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "baseline",
-        "a": "(8000, 8000, 8000)",
-        "i": "(500, 500, 500)",
-        "o": "(800, 800, 800)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(750, 750, 750)",
+        "o": "(1000, 1000, 1000)"
     },
     {
         "name": "bi_6a_200G_baseline",
@@ -512,9 +512,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "baseline",
-        "a": "(8000, 8000, 8000)",
-        "i": "(800, 800, 800)",
-        "o": "(400, 400, 400)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(1000, 1000, 1000)",
+        "o": "(600, 600, 600)"
     },
     {
         "name": "bi_6b_200G_baseline",
@@ -523,9 +523,9 @@
         "cwd": "/disk0/vhs/repartition",
         "venv": "/home/vhs/paper-repartition/.venv/bin/activate",
         "alg": "baseline",
-        "a": "(8000, 8000, 8000)",
-        "i": "(400, 400, 400)",
-        "o": "(800, 800, 800)"
+        "a": "(6000, 6000, 6000)",
+        "i": "(600, 600, 600)",
+        "o": "(1000, 1000, 1000)"
     }
 
 ]

--- a/experiments/launch.py
+++ b/experiments/launch.py
@@ -24,8 +24,8 @@ def wait(job_id):
             print(f"Slurm job {job_id} completed")
             break
 
-        else:
-            sleep(10)
+        # sleep before querying again
+        sleep(10)
 
 
 def launch(sbatch_file, nodelist):
@@ -89,14 +89,10 @@ def gen_sbatch(exp, results_dir):
         f"\n\n"
         f"repartition --max-mem {memory_bytes} --create  \"{exp['a']}\" \"{exp['i']}\" \"{exp['o']}\" {exp['alg']}\n"
         f"\n"
-        f"start=`date +%s.%N`\n"
-        f"repartition --max-mem {memory_bytes} --repartition \"{exp['a']}\" \"{exp['i']}\" \"{exp['o']}\" {exp['alg']}\n"
-        f"end=`date +%s.%N`\n"
+        f"repartition --max-mem {memory_bytes} --repartition \"{exp['a']}\" \"{exp['i']}\" \"{exp['o']}\" {exp['alg']} > {op.join(results_dir, 'runtime.txt')}\n"
         f"\n"
         f"repartition --max-mem {memory_bytes} --delete \"{exp['a']}\" \"{exp['i']}\" \"{exp['o']}\" {exp['alg']}\n"
         f"\n\n"
-        f'runtime=$( echo "$end - $start" | bc -l)\n'
-        f"echo \"Runtime: $runtime\" > {op.join(results_dir, 'runtime.txt')}\n"
         f'echo "Removing directories"\n'
         f"rm -rf {exp['cwd']}"
     )

--- a/experiments/launch.py
+++ b/experiments/launch.py
@@ -57,12 +57,12 @@ def gen_sbatch(exp, results_dir):
         f"source {exp['venv']}\n"
         f"export KEEP_LOG={log_file}"
         f"start=`date +%s.%N`\n"
-        f"repartition --max-mem {memory_bytes} --create --delete --test-data \"{exp['a']}\" \"{exp['i']}\" \"{exp['o']}\" {exp['alg']}\n"
+        f"repartition --max-mem {memory_bytes} --create --delete \"{exp['a']}\" \"{exp['i']}\" \"{exp['o']}\" {exp['alg']}\n"
         f"end=`date +%s.%N`"
         f'runtime=$( echo "$end - $start" | bc -l)\n'
         f"echo \"Runtime: $runtime\" > {op.join(results_dir, 'runtime.txt')}\n"
         f'echo "Removing directories"\n'
-        f"srun -N1 rm -rf {exp['cwd']}"
+        f"rm -rf {exp['cwd']}"
     )
 
     with open(sbatch_file, "w+") as f:
@@ -82,7 +82,9 @@ def main(conditions, repetitions, results_dir, nodelist):
     rand_exp = load(conditions)
     shuffle(rand_exp)
 
-    results_dir = op.abspath(op.join(results_dir, f"execution-{str(int(time()))}"))
+    results_dir = op.abspath(
+        op.join(results_dir, f"execution-{str(int(time()))}")
+    )
 
     for i in range(repetitions):
         for exp in rand_exp:

--- a/keep/repartition.py
+++ b/keep/repartition.py
@@ -12,88 +12,122 @@ from keep.log import log
 def main(args=None):
     parser = ArgumentParser()
 
-    parser.add_argument("A",
-                        action="store",
-                        help="shape of the reconstructed array")
-    parser.add_argument("I", action="store",
-                        help="shape of the input blocks. Input blocks "
-                             "called 'in...' must be stored on disk")
-    parser.add_argument("O", action="store",
-                        help="shape of the outut blocks. Output blocks"
-                             " called 'out...' will be created on disk")
-    parser.add_argument("--create", action="store_true",
-                        help="create input blocks on disk"
-                             " before repartitioning.")
-    parser.add_argument("--delete", action="store_true",
-                        help="delete output blocks after repartitioning.")
-    parser.add_argument("--test-data", action="store_true",
-                        help="reconstruct array from input blocks, "
-                             "reconstruct array from output blocks, "
-                             "check that data is identical in both "
-                             "reconstructions.")
-    parser.add_argument("--max-mem", action="store",
-                        help="max memory to use, in bytes")
-    parser.add_argument("method", action="store",
-                        help="repartitioning method to use",
-                        choices=["baseline", "keep"])
+    parser.add_argument(
+        "A", action="store", help="shape of the reconstructed array"
+    )
+    parser.add_argument(
+        "I",
+        action="store",
+        help="shape of the input blocks. Input blocks "
+        "called 'in...' must be stored on disk",
+    )
+    parser.add_argument(
+        "O",
+        action="store",
+        help="shape of the outut blocks. Output blocks"
+        " called 'out...' will be created on disk",
+    )
+    commands = parser.add_mutually_exclusive_group()
+    commands.add_argument(
+        "--create",
+        action="store_true",
+        help="create input blocks on disk" " before repartitioning.",
+    )
+    commands.add_argument(
+        "--repartition",
+        action="store_true",
+        help="repartition input blocks to output block dimensions",
+    )
+    commands.add_argument(
+        "--delete",
+        action="store_true",
+        help="delete output blocks after repartitioning.",
+    )
+    commands.add_argument(
+        "--test-data",
+        action="store_true",
+        help="reconstruct array from input blocks, "
+        "reconstruct array from output blocks, "
+        "check that data is identical in both "
+        "reconstructions.",
+    )
+    parser.add_argument(
+        "--max-mem", action="store", help="max memory to use, in bytes"
+    )
+    parser.add_argument(
+        "method",
+        action="store",
+        help="repartitioning method to use",
+        choices=["baseline", "keep"],
+    )
 
     args, params = parser.parse_known_args(args)
     mem = args.max_mem
     if mem is not None:
         mem = int(mem)
 
-    repart_func = {
-        'baseline': keep.baseline,
-        'keep': keep.keep
-    }
+    repart_func = {"baseline": keep.baseline, "keep": keep.keep}
 
-    array = Partition(make_tuple(args.A), name='array')
+    array = Partition(make_tuple(args.A), name="array")
+
     if args.create:
-        fill = 'random'
+        fill = "random"
+        log("Creating input blocks", 1)
     else:
         fill = None
-    
-    log('Creating input blocks', 1)
-    in_blocks = Partition(make_tuple(args.I), name='in', array=array,
-                          fill=fill)
+        log("Using existing input blocks", 1)
+
+    in_blocks = Partition(
+        make_tuple(args.I), name="in", array=array, fill=fill
+    )
     in_blocks.clear()
 
-    # Repartitioning
-    out_blocks = Partition(make_tuple(args.O), name='out', array=array)
-    out_blocks.delete()
-    out_blocks.clear()  # shouldn't be necessary but just in case
-    log('Repartitioning input blocks into output blocks', 1)
-    start = time.time()
-    (total_bytes, seeks, peak_mem,
-     read_time, write_time) = in_blocks.repartition(out_blocks,
-                                                    mem,
-                                                    repart_func[args.method])
-    end = time.time()
-    total_time = end - start
-    assert(total_time > read_time + write_time)
-    assert(total_bytes == 2*math.prod(array.shape))
-    log(f'Seeks, peak memory (B), read time (s),'
-        f' write time (s), elapsed time (s):' + os.linesep +
-        f'{seeks},{peak_mem},{round(read_time,2)},'
-        f'{round(write_time,2)},{round(total_time,2)}', 2)
+    if not args.create:
+        out_blocks = Partition(make_tuple(args.O), name="out", array=array)
 
-    if args.test_data:
-        log('Testing data', 1)
-        in_blocks.repartition(array, mem,
-                              repart_func[args.method])
-        with open(array.blocks[(0, 0, 0)].file_name, 'rb') as f:
-            in_data = f.read()
-        array.delete()
-        out_blocks.repartition(array, mem,
-                               repart_func[args.method])
-        with open(array.blocks[(0, 0, 0)].file_name, 'rb') as f:
-            out_data = f.read()
-        assert(in_data == out_data)
+        # Repartitioning
+        if args.repartition:
+            log("Repartitioning input blocks into output blocks", 1)
+            out_blocks.delete()
+            out_blocks.clear()  # shouldn't be necessary but just in case
+            start = time.time()
+            (
+                total_bytes,
+                seeks,
+                peak_mem,
+                read_time,
+                write_time,
+            ) = in_blocks.repartition(
+                out_blocks, mem, repart_func[args.method]
+            )
+            end = time.time()
+            total_time = end - start
+            assert total_time > read_time + write_time
+            assert total_bytes == 2 * math.prod(array.shape)
+            log(
+                f"Seeks, peak memory (B), read time (s),"
+                f" write time (s), elapsed time (s):"
+                + os.linesep
+                + f"{seeks},{peak_mem},{round(read_time,2)},"
+                f"{round(write_time,2)},{round(total_time,2)}",
+                2,
+            )
 
-    if args.delete:
-        log('Deleting output blocks', 1)
-        out_blocks.delete
+        if args.test_data:
+            log("Testing data", 1)
+            in_blocks.repartition(array, mem, repart_func[args.method])
+            with open(array.blocks[(0, 0, 0)].file_name, "rb") as f:
+                in_data = f.read()
+            array.delete()
+            out_blocks.repartition(array, mem, repart_func[args.method])
+            with open(array.blocks[(0, 0, 0)].file_name, "rb") as f:
+                out_data = f.read()
+            assert in_data == out_data
+
+        if args.delete:
+            log("Deleting output blocks", 1)
+            out_blocks.delete()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/keep/tests/test_repartition.py
+++ b/keep/tests/test_repartition.py
@@ -7,15 +7,25 @@ from keep.repartition import main
 @pytest.fixture
 def cleanup_blocks():
     yield
-    for f in glob.glob('*.bin'):
+    for f in glob.glob("*.bin"):
         os.remove(f)
 
 
 def test_repartition(cleanup_blocks):
-    main(['--create',
-          '--delete',
-          '--test-data',
-          '(50, 50, 50)',
-          '(5, 5, 5)',
-          '(10, 10, 10)',
-          'keep'])
+    main(["--create", "(50, 50, 50)", "(5, 5, 5)", "(10, 10, 10)", "keep"])
+
+    # verify that no output blocks have been created
+    assert len(glob.glob("out*.bin")) == 0
+    main(
+        ["--repartition", "(50, 50, 50)", "(5, 5, 5)", "(10, 10, 10)", "keep"]
+    )
+
+    # verify that output blocks have been created
+    assert len(glob.glob("out*.bin")) > 0
+
+    main(["--test-data", "(50, 50, 50)", "(5, 5, 5)", "(10, 10, 10)", "keep"])
+
+    main(["--delete", "(50, 50, 50)", "(5, 5, 5)", "(10, 10, 10)", "keep"])
+
+    # verify that all output blocks have been removed
+    assert len(glob.glob("out*.bin")) == 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.black]
+line-length = 79
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''


### PR DESCRIPTION
- Added `--repartition` flag for repartitioning blocks
- created mutually_exclusive_group for flags `--create` `--repartition` `--test_data` and `--delete`
- fixed bug in `repartition.py`
- Updated test cases to reflect updated CLI
- updated `test_repartition` test case to verify that blocks are deleted using `delete()` function
- Updated launch scripts to reflect CLI changes
- Measure makespan of repartitioning only
- launch script now waits for previous job to complete before launching a new experiment
- BI in experimental conditions is now (6000,6000,6000)
- added black precommit hook to ensure code is properly formatted before commiting